### PR TITLE
Fix wrong wording in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!-- Please fill in the **bold** fields, submit the pull request and tick the checkboxes. DO NOT SUBMIT ANYTHING IF YOU FAIL ANY OF THIS RULES -->
 
-**[Explain what this app is about and why it should be included here.]**
+**[Explain what this alias/snippet is about and why it should be included here.]**
 
 Fixes #{IssueNumber}
 <!-- Eg: Fixes #2 -->


### PR DESCRIPTION
In the github pr-template, there was a sentence about `apps` being
added. This should rather be `aliases/snippets` for this repo.

Fixes #20
