### PR TITLE
Add running of Matlab scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This repository will have collection of such aliases. Read [Contribution Guideli
     - [Get saved WiFi keys](#get-saved-wifi-keys)
     - [Take Screenshot of connected ADB Device](#take-screenshot-of-connected-adb-device)
     - [Bootstrap your CF Round](#bootstrap-your-cf-round)
+    - [Run Matlab scripts](#run-matlab-scripts)
 - [License](#license)
 
 <a id="c-cpp"></a>
@@ -258,6 +259,17 @@ cf() {
 # Usage: cf 549
 # The above command initialzes, Your CF Round folder and downloads your sample template.
 # https://files.aashutosh.dev/cpp.cpp refers to link of your template
+```
+
+<a id="matlab"></a>
+
+#### Run Matlab scripts
+
+```sh
+matlab-run() {
+    matlab -nodesktop -nosplash -r "$1"
+}
+# matlab-run filename
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ cf() {
 # https://files.aashutosh.dev/cpp.cpp refers to link of your template
 ```
 
-<a id="matlab"></a>
+<a id="run-matlab-scripts"></a>
 
 #### Run Matlab scripts
 


### PR DESCRIPTION
Added running of Matlab scripts from terminal using matlab-run filname command. The script should be saved with .m command and the command 'matlab' should be set to open matlab by default either during installation or afterwards as alias in bashrc.

<!-- Please fill in the **bold** fields, submit the pull request and tick the checkboxes. DO NOT SUBMIT ANYTHING IF YOU FAIL ANY OF THIS RULES -->

## By submitting this pull request I confirm I've read and complied with the below requirements.

Failure to properly do so will just result in the pull request being closed and everyone's time wasted. Please read it twice. Most people miss many things.

- [x] I have read the [Contribution guidelines](https://github.com/aashutoshrathi/awesome-bashrc/blob/master/CONTRIBUTING.md) and I am confident that my PR is suitable.
- [x] This pull request has a descriptive title. For example, `Add [Alias name]`, not `Update readme.md` or `Added new entries`.
- [x] The snippet/alias I added is not a duplicate.


-----
[View rendered README.md](https://github.com/thepushkarp/awesome-bashrc/blob/matlab/README.md)